### PR TITLE
build: use correct readme file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 def load_readme():
-    with io.open(os.path.join(HERE, "README.rst"), "rt", encoding="utf8") as f:
+    with io.open(os.path.join(HERE, "README.md"), "rt", encoding="utf8") as f:
         return f.read()
 
 


### PR DESCRIPTION
# Description

We renamed the readme file from `README.rst` to `README.md` but didn't update the `setup.py` file accordingly, this caused an error when installing the package.
