### PR TITLE
feat: add the mongo backup user to the initialization job

### DIFF
--- a/drydock_backups/patches/drydock-mongodb-init-job
+++ b/drydock_backups/patches/drydock-mongodb-init-job
@@ -1,0 +1,12 @@
+if (db.getUser("{{ BACKUP_MONGO_USERNAME }}") == null) {
+  db.createUser({
+      user: "{{ BACKUP_MONGO_USERNAME }}",
+      pwd:  "{{ BACKUP_MONGO_PASSWORD }}",   
+      roles: [ "backup" ],
+  })
+} else {
+  db.updateUser("{{ BACKUP_MONGO_USERNAME }}", {
+    pwd: "{{ BACKUP_MONGO_PASSWORD }}",
+    roles: [  "backup" ],
+  })
+}


### PR DESCRIPTION
# Description

Adds additional instructions to the mongo initialization job to create the backup user.

Depends on [`drydock@v16.1.0`](https://github.com/eduNEXT/drydock/releases/tag/v16.1.0).


