### PR TITLE
feat: allow to install drydock backups as non-editable and add mysql backups init job

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include drydock_backups/patches *
+recursive-include drydock_backups/templates *

--- a/drydock_backups/patches/drydock-mongodb-init-job
+++ b/drydock_backups/patches/drydock-mongodb-init-job
@@ -1,12 +1,12 @@
 if (db.getUser("{{ BACKUP_MONGO_USERNAME }}") == null) {
-  db.createUser({
-      user: "{{ BACKUP_MONGO_USERNAME }}",
-      pwd:  "{{ BACKUP_MONGO_PASSWORD }}",   
-      roles: [ "backup" ],
-  })
-} else {
-  db.updateUser("{{ BACKUP_MONGO_USERNAME }}", {
-    pwd: "{{ BACKUP_MONGO_PASSWORD }}",
-    roles: [  "backup" ],
-  })
-}
+            db.createUser({
+                user: "{{ BACKUP_MONGO_USERNAME }}",
+                pwd:  "{{ BACKUP_MONGO_PASSWORD }}",
+                roles: [ "backup" ],
+            })
+          } else {
+            db.updateUser("{{ BACKUP_MONGO_USERNAME }}", {
+              pwd: "{{ BACKUP_MONGO_PASSWORD }}",
+              roles: [  "backup" ],
+            })
+          }

--- a/drydock_backups/patches/drydock-mongodb-init-job
+++ b/drydock_backups/patches/drydock-mongodb-init-job
@@ -1,12 +1,12 @@
 if (db.getUser("{{ BACKUP_MONGO_USERNAME }}") == null) {
-            db.createUser({
-                user: "{{ BACKUP_MONGO_USERNAME }}",
-                pwd:  "{{ BACKUP_MONGO_PASSWORD }}",
-                roles: [ "backup" ],
-            })
-          } else {
-            db.updateUser("{{ BACKUP_MONGO_USERNAME }}", {
-              pwd: "{{ BACKUP_MONGO_PASSWORD }}",
-              roles: [  "backup" ],
-            })
-          }
+db.createUser({
+    user: "{{ BACKUP_MONGO_USERNAME }}",
+    pwd:  "{{ BACKUP_MONGO_PASSWORD }}",
+    roles: [ "backup" ],
+})
+} else {
+db.updateUser("{{ BACKUP_MONGO_USERNAME }}", {
+  pwd: "{{ BACKUP_MONGO_PASSWORD }}",
+  roles: [  "backup" ],
+})
+}

--- a/drydock_backups/patches/drydock-mysql-init-job
+++ b/drydock_backups/patches/drydock-mysql-init-job
@@ -1,0 +1,2 @@
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER '{{ BACKUP_MYSQL_USERNAME }}'@'%' IDENTIFIED BY '{{ BACKUP_MYSQL_PASSWORD }}';"
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "GRANT SELECT, RELOAD, PROCESS ON *.* TO '{{ BACKUP_MYSQL_USERNAME }}'@'%';"

--- a/drydock_backups/patches/drydock-mysql-init-job
+++ b/drydock_backups/patches/drydock-mysql-init-job
@@ -1,2 +1,4 @@
+{%- if BACKUP_MYSQL_USERNAME -%}
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER '{{ BACKUP_MYSQL_USERNAME }}'@'%' IDENTIFIED BY '{{ BACKUP_MYSQL_PASSWORD }}';"
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "GRANT SELECT, RELOAD, PROCESS ON *.* TO '{{ BACKUP_MYSQL_USERNAME }}'@'%';"
+{%- endif %}

--- a/drydock_backups/plugin.py
+++ b/drydock_backups/plugin.py
@@ -8,7 +8,7 @@ import click
 import pkg_resources
 from tutor import hooks
 
-from drydock.__about__ import __version__
+from drydock_backups.__about__ import __version__
 
 config = {
     "defaults": {


### PR DESCRIPTION
### Description

## Fixes

- Allow to install drydock backups as non-editable
- Use drydock-backups version instead of drydock version.
## Feat

- add mysql job creation at init jobs (depends on [this](https://github.com/eduNEXT/drydock/pull/63) )