### PR TITLE
feat: add minio expiration policy, custom storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can enable it adding `drydock-backups` to the `plugins` section of the `conf
 - **BACKUP_AZURE_CONTAINER_SAS_TOKEN**: SAS token to access the container.
 - **BACKUP_K8S_USE_EPHEMERAL_VOLUMES**: Use ephemeral volumes to set up the cronjob. (default: `False`)
 - **BACKUP_K8S_EPHEMERAL_VOLUME_SIZE**: Size of the ephemeral volume. (default: `8Gi`)
+- **BACKUP_K8S_EPHEMERAL_VOLUME_STORAGE_CLASS**: Custom StorageClass name for ephemeral volumes creation. (default: `None`)
+- **BACKUP_MINIO_EXPIRATION_DAYS**: Number of days to setup the lifecycle policy when Minio is enabled. (default: `0`)
 - **BACKUP_MYSQL_USERNAME**: Username to access the mysql database. (default: `{{ MYSQL_ROOT_USERNAME }}`)
 - **BACKUP_MYSQL_PASSWORD**: Password to access the mysql database. (default: `{{ MYSQL_ROOT_PASSWORD }}`)
 - **BACKUP_MONGO_PASSWORD**: Password to access the mongodb database. (default: `{{ MONGODB_PASSWORD }}`)

--- a/drydock_backups/patches/k8s-jobs
+++ b/drydock_backups/patches/k8s-jobs
@@ -69,6 +69,9 @@ spec:
               ephemeral:
                 volumeClaimTemplate:
                   spec:
+                    {%- if BACKUP_K8S_EPHEMERAL_VOLUME_STORAGE_CLASS %}
+                    storageClassName: {{ BACKUP_K8S_EPHEMERAL_VOLUME_STORAGE_CLASS }}
+                    {%- endif %}
                     accessModes:
                       - ReadWriteOnce
                     resources:
@@ -146,6 +149,9 @@ spec:
               ephemeral:
                 volumeClaimTemplate:
                   spec:
+                    {%- if BACKUP_K8S_EPHEMERAL_VOLUME_STORAGE_CLASS %}
+                    storageClassName: {{ BACKUP_K8S_EPHEMERAL_VOLUME_STORAGE_CLASS }}
+                    {%- endif %}
                     accessModes:
                       - ReadWriteOnce
                     resources:

--- a/drydock_backups/plugin.py
+++ b/drydock_backups/plugin.py
@@ -23,7 +23,9 @@ config = {
         "AZURE_ACCOUNT_NAME": "",
         "CUSTOM_STORAGE_ENDPOINT": None,
         "K8S_USE_EPHEMERAL_VOLUMES": False,
+        "K8S_EPHEMERAL_VOLUME_STORAGE_CLASS": None,
         "K8S_EPHEMERAL_VOLUME_SIZE": "8Gi",
+        "MINIO_EXPIRATION_DAYS": 0,
         "MYSQL_USERNAME": '{{ MYSQL_ROOT_USERNAME }}',
         "MYSQL_PASSWORD": '{{ MYSQL_ROOT_PASSWORD }}',
         "MONGO_PASSWORD": '{{ MONGODB_PASSWORD }}',
@@ -104,3 +106,11 @@ with open(
     encoding="utf-8",
 ) as fi:
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("mysql", fi.read()), priority=tutor_hooks.priorities.HIGH)
+
+@tutor_hooks.Actions.PLUGIN_LOADED.add()
+def _add_minio_init(_name: str) -> None:
+    with open(
+        str(importlib_resources.files("drydock_backups") / "templates" / "drydock_backups" / "task" / "minio" / "init"),
+        encoding="utf-8",
+    ) as fi:
+        tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(("minio", fi.read()), priority=tutor_hooks.priorities.HIGH)

--- a/drydock_backups/templates/drydock_backups/task/minio/init
+++ b/drydock_backups/templates/drydock_backups/task/minio/init
@@ -1,0 +1,5 @@
+mc config host add minio http://minio:9000 {{ OPENEDX_AWS_ACCESS_KEY }} {{ OPENEDX_AWS_SECRET_ACCESS_KEY }} --api s3v4
+mc mb --ignore-existing minio/{{ BACKUP_BUCKET_NAME }}
+{%- if BACKUP_MINIO_EXPIRATION_DAYS > 0 %}
+mc ilm add --expiry-days "{{ BACKUP_MINIO_EXPIRATION_DAYS }}" minio/{{ BACKUP_BUCKET_NAME }}
+{%- endif %}


### PR DESCRIPTION
# Description

This PR adds some features from https://github.com/eduNEXT/drydock-backups/pull/9

- BACKUP_K8S_EPHEMERAL_VOLUME_STORAGE_CLASS: Used to set custom storage class
- BACKUP_MINIO_EXPIRATION_DAYS: when minio is enabled, creates a policy with the backups bucket with a given number of days

