### PR TITLE
fix: reduce success and failed job history limit to 0

### DIFF
--- a/drydock_backups/patches/k8s-jobs
+++ b/drydock_backups/patches/k8s-jobs
@@ -9,8 +9,8 @@ spec:
   suspend: false
   schedule: {{ BACKUP_CRON_SCHEDULE }}
   startingDeadlineSeconds: 900
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -63,19 +63,6 @@ spec:
               {%- endif %}
               args:
                 - mysql
-            - name: cleanup
-              image: bitnami/kubectl
-              command:
-                - "/bin/sh"
-                - "-c"
-                - |
-                  # wait to finished the process of the backup
-                  while ! kubectl get pod $POD_NAME -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' | grep -q "Completed"; do
-                    sleep 5
-                  done
-                  # Eliminar el PVC asociado
-                  PVC_NAME=$(kubectl get pvc -l job-name=$JOB_NAME -o jsonpath='{.items[0].metadata.name}')
-                  kubectl delete pvc $PVC_NAME
           {%- if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
           volumes:
             - name: backup-volume
@@ -102,8 +89,8 @@ spec:
   suspend: false
   schedule: {{ BACKUP_CRON_SCHEDULE }}
   startingDeadlineSeconds: 900
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -156,19 +143,6 @@ spec:
               {%- endif %}
               args:
                 - mongo
-            - name: cleanup
-              image: bitnami/kubectl
-              command:
-                - "/bin/sh"
-                - "-c"
-                - |
-                  # wait to finished the process of the backup
-                  while ! kubectl get pod $POD_NAME -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' | grep -q "Completed"; do
-                    sleep 5
-                  done
-                  # Eliminar el PVC asociado
-                  PVC_NAME=$(kubectl get pvc -l job-name=$JOB_NAME -o jsonpath='{.items[0].metadata.name}')
-                  kubectl delete pvc $PVC_NAME
           {%- if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
           volumes:
             - name: backup-volume

--- a/drydock_backups/patches/k8s-jobs
+++ b/drydock_backups/patches/k8s-jobs
@@ -63,6 +63,19 @@ spec:
               {%- endif %}
               args:
                 - mysql
+            - name: cleanup
+              image: bitnami/kubectl
+              command:
+                - "/bin/sh"
+                - "-c"
+                - |
+                  # wait to finished the process of the backup
+                  while ! kubectl get pod $POD_NAME -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' | grep -q "Completed"; do
+                    sleep 5
+                  done
+                  # Eliminar el PVC asociado
+                  PVC_NAME=$(kubectl get pvc -l job-name=$JOB_NAME -o jsonpath='{.items[0].metadata.name}')
+                  kubectl delete pvc $PVC_NAME
           {%- if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
           volumes:
             - name: backup-volume
@@ -143,6 +156,19 @@ spec:
               {%- endif %}
               args:
                 - mongo
+            - name: cleanup
+              image: bitnami/kubectl
+              command:
+                - "/bin/sh"
+                - "-c"
+                - |
+                  # wait to finished the process of the backup
+                  while ! kubectl get pod $POD_NAME -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' | grep -q "Completed"; do
+                    sleep 5
+                  done
+                  # Eliminar el PVC asociado
+                  PVC_NAME=$(kubectl get pvc -l job-name=$JOB_NAME -o jsonpath='{.items[0].metadata.name}')
+                  kubectl delete pvc $PVC_NAME
           {%- if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
           volumes:
             - name: backup-volume

--- a/drydock_backups/patches/k8s-jobs
+++ b/drydock_backups/patches/k8s-jobs
@@ -10,7 +10,7 @@ spec:
   schedule: {{ BACKUP_CRON_SCHEDULE }}
   startingDeadlineSeconds: 900
   successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:
@@ -90,7 +90,7 @@ spec:
   schedule: {{ BACKUP_CRON_SCHEDULE }}
   startingDeadlineSeconds: 900
   successfulJobsHistoryLimit: 0
-  failedJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
## Description
Change in the fields configuration:
``` yml
 successfulJobsHistoryLimit: 0
failedJobsHistoryLimit: 0
```
In order not to leave pvc after a backup. 
