### PR TITLE
fix: adding role to existing user

### DIFF
--- a/drydock_backups/templates/drydock_backups/task/mongodb/init
+++ b/drydock_backups/templates/drydock_backups/task/mongodb/init
@@ -7,10 +7,10 @@ if (db.getUser("{{ BACKUP_MONGO_USERNAME }}") == null) {
       roles: [ "backup" ],
   })
   } else {
-  db.updateUser("{{ BACKUP_MONGO_USERNAME }}", {
-    pwd: "{{ BACKUP_MONGO_PASSWORD }}",
-    roles: [  "backup" ],
-  })
+  db.grantRolesToUser(
+    "{{ BACKUP_MONGO_USERNAME }}",
+    [ "backup" ]
+  )
   }
   exit
 EOF


### PR DESCRIPTION
# Description
Fix to add permissions to an existing user in Mongo, in the event that the backup user already exists and is not overwritten.